### PR TITLE
URI encode received input

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -17,7 +17,7 @@ function export_function(settings) {
         let requestURL =
           BASE_API_URL
           .replace('{apikey}', settings.key)
-          .replace('{input}', input);
+          .replace('{input}', encodeURI(input));
 
         if (options && options.cs)
           requestURL +=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cleverbot",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper for the official cleverbot API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If input contains unexpected characters(like unicode ones), they will be encoded properly instead of creating an error.

We could just do that for the requestURL string in full instead, but i went with doing so just for the user received input part.